### PR TITLE
Resize player name in match to fit space.

### DIFF
--- a/js/src/components/ControlPlayer.vue
+++ b/js/src/components/ControlPlayer.vue
@@ -13,7 +13,7 @@
      </div>
 
      <div class="slider {{player.color}}" @click="reset">
-       <div><p>{{player.displayName}}</p></div>
+       <div v-el:name>{{player.displayName}}</div>
      </div>
 
      <div v-if="match.length == 10" class="scores">
@@ -38,6 +38,7 @@
 
 <script>
 import Match from "../models/Match.js"
+import fitText from "../util/fittext.js"
 
 export default {
   name: 'ControlPlayer',
@@ -121,6 +122,10 @@ export default {
         this.reason = ''
       }
     }
+  },
+
+  ready: function () {
+    fitText(this.$els.name, this.$els.name.innerText, "'Yanone Kaffeesatz', sans-serif", 1)
   }
 }
 </script>

--- a/js/src/util/fittext.js
+++ b/js/src/util/fittext.js
@@ -1,0 +1,73 @@
+/* global getComputedStyle */
+/*!
+* FitText.js 1.0 jQuery free version
+*
+* Copyright 2011, Dave Rupert http://daverupert.com
+* Released under the WTFPL license
+* http://sam.zoy.org/wtfpl/
+* Modified by Slawomir Kolodziej http://slawekk.info
+*
+* Date: Tue Aug 09 2011 10:45:54 GMT+0200 (CEST)
+*
+* Hacked by FrontierPsycho for this project.
+*/
+/*
+let css = function (el, prop) {
+  return window.getComputedStyle ? getComputedStyle(el).getPropertyValue(prop) : el.currentStyle[prop]
+}
+*/
+
+import _ from "lodash"
+
+function addEvent (el, type, fn) {
+  if (el.addEventListener) {
+    el.addEventListener(type, fn, false)
+  } else {
+    el.attachEvent('on' + type, fn)
+  }
+}
+
+function getTextWidth (text, font) {
+  // if given, use cached canvas for better performance
+  // else, create new canvas
+  let canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"))
+  let context = canvas.getContext("2d")
+  context.font = font
+  let metrics = context.measureText(text)
+  return metrics.width
+};
+
+export default function fitText (el, text, font, desiredRatio) {
+  let fit = function (el) {
+    let resizer = function () {
+      let currentFontSize = _.trimEnd(getComputedStyle(el, null).getPropertyValue("font-size"), "px")
+      let fontString = `${currentFontSize}px ${font}`
+
+      let currentRatio = getTextWidth(text, fontString) / parseFloat(el.clientWidth)
+      let newFontSize = currentFontSize * (parseFloat(desiredRatio) / currentRatio)
+
+      console.debug("currentRatio:", currentRatio, "currentFontSize:", currentFontSize, "newFontSize:", newFontSize)
+
+      el.style.fontSize = newFontSize + "px"
+    }
+
+    // Call once to set.
+    resizer()
+
+    // Bind events
+    // If you have any js library which support Events, replace this part
+    // and remove addEvent function (or use original jQuery version)
+    addEvent(window, 'resize', resizer)
+  }
+
+  if (el.length) {
+    for (var i = 0; i < el.length; i++) {
+      fit(el[i])
+    }
+  } else {
+    fit(el)
+  }
+
+  // return set of elements
+  return el
+}


### PR DESCRIPTION
Before, names all had the same font size, causing some to be displayed correctly, and some to be clipped.

With this, the player name tries to be about 80% the width of its container.

It doesn't work perfectly because Yanone Kaffeesatz is very very narrow, but it seems to produce good results. Try it!