### PR TITLE
Fish with a sparkle of damn

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-cd $(dirname $(readlink -f $0))
-
 # Check that we have the things that we need to run this
 error=false
 for x in go npm nginx; do

--- a/faking.go
+++ b/faking.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"fmt"
 	roman "github.com/StefanSchroeder/Golang-Roman"
 	"io/ioutil"
@@ -17,9 +18,16 @@ type Cracklib []string
 var words Cracklib
 
 func init() {
-	out, err := ioutil.ReadFile("/usr/share/cracklib/cracklib-small")
+	cracklib_location := os.Getenv("DF_CRACKLIB_LOCATION")
+	default_cracklib_location := "/usr/share/cracklib/cracklib-small"
+	if cracklib_location == "" {
+		log.Print("Cracklib location set to default: " + default_cracklib_location)
+
+		cracklib_location = default_cracklib_location
+	}
+	out, err := ioutil.ReadFile(cracklib_location)
 	if err != nil {
-		log.Print("Cracklib failed to load.")
+		log.Print("Cracklib failed to load. Set location by env variable DF_CRACKLIB_LOCATION")
 		return
 	}
 	words = removeApostrophes(strings.Split(string(out), "\n"))

--- a/js/src/components/Match.vue
+++ b/js/src/components/Match.vue
@@ -97,7 +97,7 @@ export default {
       this.$set('updated', Date.now())
     },
     end: function () {
-      this.api.toggle({ id: this.tournament.id, kind: this.match.kind, index: this.match.index }).then(function (res) {
+      this.api.end({ id: this.tournament.id, kind: this.match.kind, index: this.match.index }).then(function (res) {
         console.log(res)
         this.$route.router.go('/towerfall/' + this.tournament.id + '/')
       }, function (res) {
@@ -106,7 +106,7 @@ export default {
       })
     },
     start: function () {
-      this.api.toggle({ id: this.tournament.id, kind: this.match.kind, index: this.match.index }).then(function (res) {
+      this.api.start({ id: this.tournament.id, kind: this.match.kind, index: this.match.index }).then(function (res) {
         console.log(res)
         this.setData(
           res.data.tournament,
@@ -139,7 +139,8 @@ export default {
     console.debug("Creating API resource")
     let customActions = {
       commit: { method: "POST", url: "/api/towerfall/tournament{/id}{/kind}{/index}/commit/" },
-      toggle: { method: "GET", url: "/api/towerfall/tournament{/id}{/kind}{/index}/toggle/" },
+      start: { method: "GET", url: "/api/towerfall/tournament{/id}{/kind}{/index}/start/" },
+      end: { method: "GET", url: "/api/towerfall/tournament{/id}{/kind}{/index}/end/" },
       getTournamentData: { method: "GET", url: "/api/towerfall/tournament{/id}/" }
     }
     this.api = this.$resource("/api/towerfall", {}, customActions)


### PR DESCRIPTION
toggle is now two functions 

- Modifies the frontend api to use the two endpoints /start and /end instead of /toggle.
- Using the new MatchHandler, create two different API endpoints in the backend for starting and stopping a match. This should ensure that a match cannot be started/stopped twice.

Also fixes general setup problems related to OS X. Specifically: 

- readlink behaves stupidly on OS X compared to Linux
- Custom location for cracklib using env variable DF_CRACKLIB_LOCATION